### PR TITLE
Feature: Implement Route Detail

### DIFF
--- a/app/src/main/assets/api/route_detail_1.json
+++ b/app/src/main/assets/api/route_detail_1.json
@@ -1,0 +1,25 @@
+{
+  "id": 2,
+  "cityId": 1,
+  "title": "1-Day Itinerary",
+  "segments": [
+    {
+      "id": 101,
+      "title": "Day 1 – Old Town",
+      "dayIndex": 1,
+      "stops": [
+        { "ord": 1,  "placeId": 1001, "name": "Marienplatz",                 "category": "LANDMARK" },
+        { "ord": 2,  "placeId": 1002, "name": "Viktualienmarkt",             "category": "FOOD" },
+        { "ord": 3,  "placeId": 1003, "name": "Frauenkirche",                 "category": "LANDMARK" },
+        { "ord": 4,  "placeId": 1004, "name": "St. Peter Kirche", "category": "VIEWPOINT" },
+        { "ord": 5,  "placeId": 1005, "name": "Max-Joseph-Platz",             "category": "LANDMARK" },
+        { "ord": 6,  "placeId": 1006, "name": "Kanso",                        "category": "COFFEE" },
+        { "ord": 7,  "placeId": 1007, "name": "Odeonsplatz",                  "category": "LANDMARK" },
+        { "ord": 8,  "placeId": 1008, "name": "Theatinerkirche",              "category": "LANDMARK" },
+        { "ord": 9,  "placeId": 1009, "name": "Residenz & Hofgarten",         "category": "LANDMARK" },
+        { "ord": 10, "placeId": 1010, "name": "Eisbachwelle",                 "category": "VIEWPOINT" }
+      ]
+    }
+  ],
+  "updatedAt": "2025-08-14T12:00:00Z"
+}

--- a/app/src/main/assets/api/route_detail_1.json
+++ b/app/src/main/assets/api/route_detail_1.json
@@ -1,5 +1,5 @@
 {
-  "id": 2,
+  "id": 1,
   "cityId": 1,
   "title": "1-Day Itinerary",
   "segments": [

--- a/app/src/main/assets/api/route_detail_2.json
+++ b/app/src/main/assets/api/route_detail_2.json
@@ -1,5 +1,5 @@
 {
-  "id": 3,
+  "id": 2,
   "cityId": 1,
   "title": "3-Day Itinerary",
   "segments": [

--- a/app/src/main/assets/api/route_detail_2.json
+++ b/app/src/main/assets/api/route_detail_2.json
@@ -1,0 +1,47 @@
+{
+  "id": 3,
+  "cityId": 1,
+  "title": "3-Day Itinerary",
+  "segments": [
+    {
+      "id": 301,
+      "title": "Day 1 – Old Town",
+      "dayIndex": 1,
+      "stops": [
+        { "ord": 1,  "placeId": 1001, "name": "Marienplatz",          "category": "LANDMARK" },
+        { "ord": 2,  "placeId": 1002, "name": "Viktualienmarkt",      "category": "FOOD" },
+        { "ord": 3,  "placeId": 1003, "name": "Frauenkirche",         "category": "LANDMARK" },
+        { "ord": 4,  "placeId": 1004, "name": "St. Peter Kirche",     "category": "VIEWPOINT" },
+        { "ord": 5,  "placeId": 1005, "name": "Max-Joseph-Platz",     "category": "LANDMARK" },
+        { "ord": 6,  "placeId": 1006, "name": "Kanso",                "category": "COFFEE" },
+        { "ord": 7,  "placeId": 1007, "name": "Odeonsplatz",          "category": "LANDMARK" },
+        { "ord": 8,  "placeId": 1008, "name": "Theatinerkirche",      "category": "LANDMARK" },
+        { "ord": 9,  "placeId": 1009, "name": "Residenz & Hofgarten", "category": "LANDMARK" },
+        { "ord": 10, "placeId": 1011, "name": "Hofbräuhaus",          "category": "FOOD" }
+      ]
+    },
+    {
+      "id": 302,
+      "title": "Day 2 – Museums & Palace",
+      "dayIndex": 2,
+      "stops": [
+        { "ord": 1, "placeId": 1012, "name": "Alte Pinakothek",     "category": "MUSEUM" },
+        { "ord": 2, "placeId": 1013, "name": "Nymphenburg Palace", "category": "LANDMARK" },
+        { "ord": 3, "placeId": 1014, "name": "Englischer Garten",  "category": "VIEWPOINT" },
+        { "ord": 4, "placeId": 1010, "name": "Eisbachwelle",       "category": "VIEWPOINT" }
+      ]
+    },
+    {
+      "id": 303,
+      "title": "Day 3 – Science & Modern Munich",
+      "dayIndex": 3,
+      "stops": [
+        { "ord": 1, "placeId": 1015, "name": "Deutsches Museum", "category": "MUSEUM" },
+        { "ord": 2, "placeId": 1016, "name": "Olympiapark",      "category": "LANDMARK" },
+        { "ord": 3, "placeId": 1017, "name": "BMW Museum",       "category": "MUSEUM" },
+        { "ord": 4, "placeId": 1018, "name": "BMW Welt",         "category": "LANDMARK" }
+      ]
+    }
+  ],
+  "updatedAt": "2025-08-29T12:30:00Z"
+}

--- a/app/src/main/assets/api/routes_1.json
+++ b/app/src/main/assets/api/routes_1.json
@@ -2,7 +2,7 @@
   "cityId": 1,
   "routes": [
     { "id": 1, "title": "1-Day Itinerary", "summary": "Old Town highlights + coffee break" },
-    { "id": 2, "title": "3-Day Itinerary", "summary": "Old Town, Museums, parks and cafés" }
+    { "id": 2, "title": "3-Day Itinerary", "summary": "Old Town, Museums and parks" }
   ]
 }
 

--- a/app/src/main/java/com/github/eylulnc/walkmunich/core/data/model/Route.kt
+++ b/app/src/main/java/com/github/eylulnc/walkmunich/core/data/model/Route.kt
@@ -15,17 +15,16 @@ data class RoutesResponse(
     val routes: List<RouteSummary>
 )
 
+@Serializable
 data class RouteDetail(
     val id: Long,
     val cityId: Long,
     val title: String,
-    val targetBreakEveryMin: Int?,
-    val maxDetourMin: Int?,
-    val paceMinPerKm: Int?,
     val segments: List<RouteSegment>,
     val updatedAt: String
 )
 
+@Serializable
 data class RouteSegment(
     val id: Long,
     val title: String,
@@ -33,6 +32,7 @@ data class RouteSegment(
     val stops: List<RouteStop>
 )
 
+@Serializable
 data class RouteStop(
     val ord: Int,
     val placeId: Long,

--- a/app/src/main/java/com/github/eylulnc/walkmunich/core/ui/composable/PlaceOverviewCard.kt
+++ b/app/src/main/java/com/github/eylulnc/walkmunich/core/ui/composable/PlaceOverviewCard.kt
@@ -1,0 +1,90 @@
+package com.github.eylulnc.walkmunich.core.ui.composable
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import com.github.eylulnc.walkmunich.core.data.model.Place
+import com.github.eylulnc.walkmunich.core.data.model.toUi
+import com.github.eylulnc.walkmunich.core.ui.theme.Spacing
+import com.github.eylulnc.walkmunich.core.ui.util.ImageResolver
+
+@Composable
+fun PlaceOverviewCard(
+    place: Place,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Card(
+        modifier = modifier
+            .fillMaxWidth()
+            .clickable { onClick() },
+        colors = CardDefaults.cardColors(
+            containerColor = Color.White
+        ),
+        elevation = CardDefaults.cardElevation(
+            defaultElevation = Spacing.Small
+        )
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(Spacing.Medium),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+
+            val imageResId = ImageResolver.resolveDrawable(place.imageUrl)
+
+            Image(
+                painter = painterResource(id = imageResId),
+                contentDescription = place.name,
+                modifier = Modifier
+                    .size(Spacing.SearchBarImageSize)
+                    .clip(RoundedCornerShape(Spacing.Small)),
+                contentScale = ContentScale.Crop
+            )
+
+            Spacer(modifier = Modifier.width(Spacing.Medium))
+
+            // Place details
+            Column(
+                modifier = Modifier.weight(1f)
+            ) {
+                Text(
+                    text = place.name,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Medium
+                )
+
+                Spacer(modifier = Modifier.height(Spacing.ExtraSmall))
+
+                val category = place.category.toUi()
+                Text(
+                    text = stringResource(category.titleResource),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = Color.Gray
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/github/eylulnc/walkmunich/di/AppModule.kt
+++ b/app/src/main/java/com/github/eylulnc/walkmunich/di/AppModule.kt
@@ -1,12 +1,12 @@
 package com.github.eylulnc.walkmunich.di
 
-import com.github.eylulnc.walkmunich.feature.main.data.city.repository.CityRepository
-import com.github.eylulnc.walkmunich.feature.main.data.city.service.CityService
-import com.github.eylulnc.walkmunich.feature.main.data.city.service.CityServiceImpl
-import com.github.eylulnc.walkmunich.feature.main.data.place.repository.PlacesRepository
-import com.github.eylulnc.walkmunich.feature.main.data.place.service.PlacesService
-import com.github.eylulnc.walkmunich.feature.main.data.place.service.PlacesServiceImpl
-import com.github.eylulnc.walkmunich.feature.main.viewModel.MainScreenViewModel
+import com.github.eylulnc.walkmunich.feature.home.data.city.repository.CityRepository
+import com.github.eylulnc.walkmunich.feature.home.data.city.service.CityService
+import com.github.eylulnc.walkmunich.feature.home.data.city.service.CityServiceImpl
+import com.github.eylulnc.walkmunich.feature.home.data.place.repository.PlacesRepository
+import com.github.eylulnc.walkmunich.feature.home.data.place.service.PlacesService
+import com.github.eylulnc.walkmunich.feature.home.data.place.service.PlacesServiceImpl
+import com.github.eylulnc.walkmunich.feature.home.viewModel.MainScreenViewModel
 import com.github.eylulnc.walkmunich.feature.route.data.RoutesRepository
 import com.github.eylulnc.walkmunich.feature.route.data.RoutesService
 import com.github.eylulnc.walkmunich.feature.route.data.RoutesServiceImpl

--- a/app/src/main/java/com/github/eylulnc/walkmunich/di/AppModule.kt
+++ b/app/src/main/java/com/github/eylulnc/walkmunich/di/AppModule.kt
@@ -10,6 +10,7 @@ import com.github.eylulnc.walkmunich.feature.home.viewModel.MainScreenViewModel
 import com.github.eylulnc.walkmunich.feature.route.data.RoutesRepository
 import com.github.eylulnc.walkmunich.feature.route.data.RoutesService
 import com.github.eylulnc.walkmunich.feature.route.data.RoutesServiceImpl
+import com.github.eylulnc.walkmunich.feature.route.viewmodel.RouteDetailViewModel
 import com.github.eylulnc.walkmunich.feature.route.viewmodel.RouteListViewModel
 import kotlinx.serialization.json.Json
 import org.koin.android.ext.koin.androidContext
@@ -30,4 +31,5 @@ val appModule = module {
 
     viewModelOf(::MainScreenViewModel)
     viewModelOf(::RouteListViewModel)
+    viewModelOf(::RouteDetailViewModel)
 }

--- a/app/src/main/java/com/github/eylulnc/walkmunich/di/AppModule.kt
+++ b/app/src/main/java/com/github/eylulnc/walkmunich/di/AppModule.kt
@@ -1,6 +1,5 @@
 package com.github.eylulnc.walkmunich.di
 
-import androidx.lifecycle.viewmodel.compose.viewModel
 import com.github.eylulnc.walkmunich.feature.home.data.city.repository.CityRepository
 import com.github.eylulnc.walkmunich.feature.home.data.city.service.CityService
 import com.github.eylulnc.walkmunich.feature.home.data.city.service.CityServiceImpl
@@ -15,7 +14,6 @@ import com.github.eylulnc.walkmunich.feature.route.viewmodel.RouteDetailViewMode
 import com.github.eylulnc.walkmunich.feature.route.viewmodel.RouteListViewModel
 import kotlinx.serialization.json.Json
 import org.koin.android.ext.koin.androidContext
-import org.koin.core.module.dsl.factoryOf
 import org.koin.core.module.dsl.viewModelOf
 import org.koin.dsl.module
 

--- a/app/src/main/java/com/github/eylulnc/walkmunich/di/AppModule.kt
+++ b/app/src/main/java/com/github/eylulnc/walkmunich/di/AppModule.kt
@@ -14,6 +14,7 @@ import com.github.eylulnc.walkmunich.feature.route.viewmodel.RouteDetailViewMode
 import com.github.eylulnc.walkmunich.feature.route.viewmodel.RouteListViewModel
 import kotlinx.serialization.json.Json
 import org.koin.android.ext.koin.androidContext
+import org.koin.core.module.dsl.factoryOf
 import org.koin.core.module.dsl.viewModelOf
 import org.koin.dsl.module
 
@@ -31,5 +32,5 @@ val appModule = module {
 
     viewModelOf(::MainScreenViewModel)
     viewModelOf(::RouteListViewModel)
-    viewModelOf(::RouteDetailViewModel)
+    factoryOf(::RouteDetailViewModel)
 }

--- a/app/src/main/java/com/github/eylulnc/walkmunich/di/AppModule.kt
+++ b/app/src/main/java/com/github/eylulnc/walkmunich/di/AppModule.kt
@@ -1,5 +1,6 @@
 package com.github.eylulnc.walkmunich.di
 
+import androidx.lifecycle.viewmodel.compose.viewModel
 import com.github.eylulnc.walkmunich.feature.home.data.city.repository.CityRepository
 import com.github.eylulnc.walkmunich.feature.home.data.city.service.CityService
 import com.github.eylulnc.walkmunich.feature.home.data.city.service.CityServiceImpl
@@ -32,5 +33,5 @@ val appModule = module {
 
     viewModelOf(::MainScreenViewModel)
     viewModelOf(::RouteListViewModel)
-    factoryOf(::RouteDetailViewModel)
+    viewModelOf(::RouteDetailViewModel)
 }

--- a/app/src/main/java/com/github/eylulnc/walkmunich/feature/home/data/city/repository/CityRepository.kt
+++ b/app/src/main/java/com/github/eylulnc/walkmunich/feature/home/data/city/repository/CityRepository.kt
@@ -1,7 +1,7 @@
-package com.github.eylulnc.walkmunich.feature.main.data.city.repository
+package com.github.eylulnc.walkmunich.feature.home.data.city.repository
 
 import com.github.eylulnc.walkmunich.core.data.model.City
-import com.github.eylulnc.walkmunich.feature.main.data.city.service.CityService
+import com.github.eylulnc.walkmunich.feature.home.data.city.service.CityService
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 

--- a/app/src/main/java/com/github/eylulnc/walkmunich/feature/home/data/city/service/CityService.kt
+++ b/app/src/main/java/com/github/eylulnc/walkmunich/feature/home/data/city/service/CityService.kt
@@ -1,4 +1,4 @@
-package com.github.eylulnc.walkmunich.feature.main.data.city.service
+package com.github.eylulnc.walkmunich.feature.home.data.city.service
 
 import com.github.eylulnc.walkmunich.core.data.model.City
 

--- a/app/src/main/java/com/github/eylulnc/walkmunich/feature/home/data/city/service/CityServiceImpl.kt
+++ b/app/src/main/java/com/github/eylulnc/walkmunich/feature/home/data/city/service/CityServiceImpl.kt
@@ -1,4 +1,4 @@
-package com.github.eylulnc.walkmunich.feature.main.data.city.service
+package com.github.eylulnc.walkmunich.feature.home.data.city.service
 
 import android.content.Context
 import com.github.eylulnc.walkmunich.core.data.model.City

--- a/app/src/main/java/com/github/eylulnc/walkmunich/feature/home/data/place/repository/PlacesRepository.kt
+++ b/app/src/main/java/com/github/eylulnc/walkmunich/feature/home/data/place/repository/PlacesRepository.kt
@@ -1,7 +1,7 @@
-package com.github.eylulnc.walkmunich.feature.main.data.place.repository
+package com.github.eylulnc.walkmunich.feature.home.data.place.repository
 
 import com.github.eylulnc.walkmunich.core.data.model.Place
-import com.github.eylulnc.walkmunich.feature.main.data.place.service.PlacesService
+import com.github.eylulnc.walkmunich.feature.home.data.place.service.PlacesService
 
 class PlacesRepository(
     private val service: PlacesService

--- a/app/src/main/java/com/github/eylulnc/walkmunich/feature/home/data/place/service/PlacesService.kt
+++ b/app/src/main/java/com/github/eylulnc/walkmunich/feature/home/data/place/service/PlacesService.kt
@@ -1,4 +1,4 @@
-package com.github.eylulnc.walkmunich.feature.main.data.place.service
+package com.github.eylulnc.walkmunich.feature.home.data.place.service
 
 import com.github.eylulnc.walkmunich.core.data.model.Place
 

--- a/app/src/main/java/com/github/eylulnc/walkmunich/feature/home/data/place/service/PlacesServiceImpl.kt
+++ b/app/src/main/java/com/github/eylulnc/walkmunich/feature/home/data/place/service/PlacesServiceImpl.kt
@@ -1,4 +1,4 @@
-package com.github.eylulnc.walkmunich.feature.main.data.place.service
+package com.github.eylulnc.walkmunich.feature.home.data.place.service
 
 import android.content.Context
 import com.github.eylulnc.walkmunich.core.data.model.Place

--- a/app/src/main/java/com/github/eylulnc/walkmunich/feature/home/ui/HomeScreenUi.kt
+++ b/app/src/main/java/com/github/eylulnc/walkmunich/feature/home/ui/HomeScreenUi.kt
@@ -1,4 +1,4 @@
-package com.github.eylulnc.walkmunich.feature.main.ui
+package com.github.eylulnc.walkmunich.feature.home.ui
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -43,7 +43,7 @@ import com.github.eylulnc.walkmunich.core.ui.theme.OrangeMain
 import com.github.eylulnc.walkmunich.core.ui.theme.Spacing
 import com.github.eylulnc.walkmunich.core.ui.theme.TypographySizes
 import com.github.eylulnc.walkmunich.core.ui.util.ImageResolver
-import com.github.eylulnc.walkmunich.feature.main.viewModel.MainScreenViewModel
+import com.github.eylulnc.walkmunich.feature.home.viewModel.MainScreenViewModel
 import org.koin.androidx.compose.koinViewModel
 
 @Composable

--- a/app/src/main/java/com/github/eylulnc/walkmunich/feature/home/ui/HomeScreenUi.kt
+++ b/app/src/main/java/com/github/eylulnc/walkmunich/feature/home/ui/HomeScreenUi.kt
@@ -20,7 +20,6 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField

--- a/app/src/main/java/com/github/eylulnc/walkmunich/feature/home/ui/HomeScreenUi.kt
+++ b/app/src/main/java/com/github/eylulnc/walkmunich/feature/home/ui/HomeScreenUi.kt
@@ -117,7 +117,6 @@ private fun HeaderSection(
 
         Text(
             text = cityName,
-            style = MaterialTheme.typography.headlineLarge,
             color = Color.White,
             fontWeight = FontWeight.ExtraBold,
             fontSize = TypographySizes.heroTitle,
@@ -153,7 +152,6 @@ private fun CategoriesSection(
     ) {
         Text(
             text = stringResource(R.string.category_title),
-            style = MaterialTheme.typography.headlineSmall,
             fontSize = TypographySizes.large,
             fontWeight = FontWeight.Bold,
             color = Color.Black,

--- a/app/src/main/java/com/github/eylulnc/walkmunich/feature/home/ui/SearchResultsSection.kt
+++ b/app/src/main/java/com/github/eylulnc/walkmunich/feature/home/ui/SearchResultsSection.kt
@@ -1,6 +1,5 @@
-package com.github.eylulnc.walkmunich.feature.main.ui
+package com.github.eylulnc.walkmunich.feature.home.ui
 
-import android.content.res.Resources
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement

--- a/app/src/main/java/com/github/eylulnc/walkmunich/feature/home/ui/SearchResultsSection.kt
+++ b/app/src/main/java/com/github/eylulnc/walkmunich/feature/home/ui/SearchResultsSection.kt
@@ -1,41 +1,26 @@
 package com.github.eylulnc.walkmunich.feature.home.ui
 
-import androidx.compose.foundation.Image
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import com.github.eylulnc.walkmunich.R
 import com.github.eylulnc.walkmunich.core.data.model.Place
 import com.github.eylulnc.walkmunich.core.data.model.SearchResult
-import com.github.eylulnc.walkmunich.core.data.model.toUi
 import com.github.eylulnc.walkmunich.core.ui.theme.Spacing
 import com.github.eylulnc.walkmunich.core.ui.theme.TypographySizes
-import com.github.eylulnc.walkmunich.core.ui.util.ImageResolver
+import com.github.eylulnc.walkmunich.core.ui.composable.PlaceOverviewCard
 
 @Composable
 fun SearchResultsSection(
@@ -77,8 +62,8 @@ fun SearchResultsSection(
                 verticalArrangement = Arrangement.spacedBy(Spacing.ItemGap)
             ) {
                 items(searchResults) { searchResult ->
-                    SearchResultCard(
-                        searchResult = searchResult,
+                    PlaceOverviewCard(
+                        place = searchResult.place,
                         onClick = { onPlaceClick(searchResult.place) }
                     )
                 }
@@ -97,64 +82,3 @@ fun SearchResultsSection(
     }
 }
 
-@Composable
-private fun SearchResultCard(
-    searchResult: SearchResult,
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier
-) {
-    Card(
-        modifier = modifier
-            .fillMaxWidth()
-            .clickable { onClick() },
-        colors = CardDefaults.cardColors(
-            containerColor = Color.White
-        ),
-        elevation = CardDefaults.cardElevation(
-            defaultElevation = Spacing.Small
-        )
-    ) {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(Spacing.Medium),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            //  Place image - use actual place image if available, fallback to hero image
-            // TODO add related images
-            val imageResId = ImageResolver.resolveDrawable(searchResult.place.imageUrl)
-                ?: R.drawable.hero_munich // fallback
-            
-            Image(
-                painter = painterResource(id = imageResId),
-                contentDescription = searchResult.place.name,
-                modifier = Modifier
-                    .size(Spacing.SearchBarImageSize)
-                    .clip(RoundedCornerShape(Spacing.Small)),
-                contentScale = ContentScale.Crop
-            )
-            
-            Spacer(modifier = Modifier.width(Spacing.Medium))
-            
-            // Place details
-            Column(
-                modifier = Modifier.weight(1f)
-            ) {
-                Text(
-                    text = searchResult.place.name,
-                    style = MaterialTheme.typography.titleMedium,
-                    fontWeight = FontWeight.Medium
-                )
-                
-                Spacer(modifier = Modifier.height(Spacing.ExtraSmall))
-
-                val category = searchResult.category.toUi()
-                Text(
-                    text = stringResource(category.titleResource),
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = Color.Gray
-                )
-            }
-        }
-    }
-}

--- a/app/src/main/java/com/github/eylulnc/walkmunich/feature/home/viewModel/HomeScreenViewModel.kt
+++ b/app/src/main/java/com/github/eylulnc/walkmunich/feature/home/viewModel/HomeScreenViewModel.kt
@@ -1,12 +1,12 @@
-package com.github.eylulnc.walkmunich.feature.main.viewModel
+package com.github.eylulnc.walkmunich.feature.home.viewModel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.github.eylulnc.walkmunich.core.data.model.City
 import com.github.eylulnc.walkmunich.core.data.model.Place
 import com.github.eylulnc.walkmunich.core.data.model.SearchResult
-import com.github.eylulnc.walkmunich.feature.main.data.city.repository.CityRepository
-import com.github.eylulnc.walkmunich.feature.main.data.place.repository.PlacesRepository
+import com.github.eylulnc.walkmunich.feature.home.data.city.repository.CityRepository
+import com.github.eylulnc.walkmunich.feature.home.data.place.repository.PlacesRepository
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow

--- a/app/src/main/java/com/github/eylulnc/walkmunich/feature/route/data/RoutesRepository.kt
+++ b/app/src/main/java/com/github/eylulnc/walkmunich/feature/route/data/RoutesRepository.kt
@@ -1,11 +1,13 @@
 package com.github.eylulnc.walkmunich.feature.route.data
 
+import com.github.eylulnc.walkmunich.core.data.model.RouteDetail
 import com.github.eylulnc.walkmunich.core.data.model.RouteSummary
 
 class RoutesRepository(
     private val service: RoutesService
 ) {
     suspend fun getRoutes(cityId: Long): List<RouteSummary> = service.fetchRoutes(cityId)
+    suspend fun getRouteDetail(routeId: Long): RouteDetail = service.fetchRouteDetail(routeId)
 }
 
 

--- a/app/src/main/java/com/github/eylulnc/walkmunich/feature/route/data/RoutesService.kt
+++ b/app/src/main/java/com/github/eylulnc/walkmunich/feature/route/data/RoutesService.kt
@@ -1,9 +1,11 @@
 package com.github.eylulnc.walkmunich.feature.route.data
 
+import com.github.eylulnc.walkmunich.core.data.model.RouteDetail
 import com.github.eylulnc.walkmunich.core.data.model.RouteSummary
 
 interface RoutesService {
     suspend fun fetchRoutes(cityId: Long): List<RouteSummary>
+    suspend fun fetchRouteDetail(routeId: Long): RouteDetail
 }
 
 

--- a/app/src/main/java/com/github/eylulnc/walkmunich/feature/route/data/RoutesServiceImpl.kt
+++ b/app/src/main/java/com/github/eylulnc/walkmunich/feature/route/data/RoutesServiceImpl.kt
@@ -1,6 +1,7 @@
 package com.github.eylulnc.walkmunich.feature.route.data
 
 import android.content.Context
+import com.github.eylulnc.walkmunich.core.data.model.RouteDetail
 import com.github.eylulnc.walkmunich.core.data.model.RouteSummary
 import com.github.eylulnc.walkmunich.core.data.model.RoutesResponse
 import kotlinx.coroutines.Dispatchers
@@ -18,6 +19,13 @@ class RoutesServiceImpl(
         val path = "api/routes_$cityId.json"
         val text = context.assets.open(path).bufferedReader().use { it.readText() }
         json.decodeFromString(RoutesResponse.serializer(), text).routes
+    }
+
+    override suspend fun fetchRouteDetail(routeId: Long): RouteDetail = withContext(Dispatchers.IO) {
+        delay(300)
+        val path = "api/route_detail_$routeId.json"
+        val text = context.assets.open(path).bufferedReader().use { it.readText() }
+        json.decodeFromString(RouteDetail.serializer(), text)
     }
 }
 

--- a/app/src/main/java/com/github/eylulnc/walkmunich/feature/route/ui/RouteDetailScreenUi.kt
+++ b/app/src/main/java/com/github/eylulnc/walkmunich/feature/route/ui/RouteDetailScreenUi.kt
@@ -19,14 +19,12 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
@@ -110,13 +108,15 @@ fun RouteDetailScreenUi(
                     ) {
                         Text(
                             text = "Error loading route",
-                            style = MaterialTheme.typography.titleMedium,
+                            fontSize = TypographySizes.large,
+                            fontWeight = FontWeight.Bold,
                             color = Color.Red
                         )
                         Spacer(modifier = Modifier.height(Spacing.Small))
                         Text(
                             text = state.error ?: "Unknown error",
-                            style = MaterialTheme.typography.bodyMedium,
+                            fontSize = TypographySizes.medium,
+                            fontWeight = FontWeight.Bold,
                             color = Color.Gray
                         )
                     }

--- a/app/src/main/java/com/github/eylulnc/walkmunich/feature/route/ui/RouteDetailScreenUi.kt
+++ b/app/src/main/java/com/github/eylulnc/walkmunich/feature/route/ui/RouteDetailScreenUi.kt
@@ -1,0 +1,282 @@
+package com.github.eylulnc.walkmunich.feature.route.ui
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeContentPadding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.Place
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.github.eylulnc.walkmunich.core.data.model.RouteDetail
+import com.github.eylulnc.walkmunich.core.data.model.RouteStop
+import com.github.eylulnc.walkmunich.core.data.model.toUi
+import com.github.eylulnc.walkmunich.core.ui.theme.OrangeMain
+import com.github.eylulnc.walkmunich.core.ui.theme.Spacing
+import com.github.eylulnc.walkmunich.feature.route.viewmodel.RouteDetailViewModel
+import org.koin.androidx.compose.koinViewModel
+import org.koin.core.parameter.parametersOf
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun RouteDetailScreenUi(
+    routeId: Long,
+    onBackClick: () -> Unit
+) {
+    val viewModel: RouteDetailViewModel = koinViewModel<RouteDetailViewModel> { 
+        parametersOf(routeId) 
+    }
+    
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color.White)
+    ) {
+        TopAppBar(
+            title = { 
+                Text(
+                    text = state.routeDetail?.title ?: "Route Details",
+                    style = MaterialTheme.typography.titleLarge,
+                    fontWeight = FontWeight.Bold
+                )
+            },
+            navigationIcon = {
+                IconButton(onClick = onBackClick) {
+                    Icon(
+                        imageVector = Icons.Default.ArrowBack,
+                        contentDescription = "Back",
+                        tint = OrangeMain
+                    )
+                }
+            },
+            colors = TopAppBarDefaults.topAppBarColors(
+                containerColor = Color.White,
+                titleContentColor = Color.Black
+            )
+        )
+        
+        when {
+            state.isLoading -> {
+                Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center
+                ) {
+                    CircularProgressIndicator(color = OrangeMain)
+                }
+            }
+            state.error != null -> {
+                Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Column(
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
+                        Text(
+                            text = "Error loading route",
+                            style = MaterialTheme.typography.titleMedium,
+                            color = Color.Red
+                        )
+                        Spacer(modifier = Modifier.height(Spacing.Small))
+                        Text(
+                            text = state.error ?: "Unknown error",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = Color.Gray
+                        )
+                    }
+                }
+            }
+            state.routeDetail != null -> {
+                RouteDetailContent(routeDetail = state.routeDetail!!)
+            }
+        }
+    }
+}
+
+@Composable
+private fun RouteDetailContent(routeDetail: RouteDetail) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(horizontal = Spacing.Medium)
+    ) {
+        // Route stops visualization
+        RouteStopsVisualization(routeDetail.segments.flatMap { it.stops })
+    }
+}
+
+@Composable
+private fun RouteStopsVisualization(stops: List<RouteStop>) {
+    Column(
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        stops.forEachIndexed { index, stop ->
+            RouteStopItem(
+                stop = stop,
+                isLast = index == stops.size - 1,
+                showConnector = index < stops.size - 1
+            )
+        }
+    }
+}
+
+@Composable
+private fun RouteStopItem(
+    stop: RouteStop,
+    isLast: Boolean,
+    showConnector: Boolean
+) {
+    Column(
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.Top
+        ) {
+            // Stop number circle
+            Box(
+                modifier = Modifier
+                    .size(40.dp)
+                    .clip(CircleShape)
+                    .background(OrangeMain),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(
+                    text = stop.ord.toString(),
+                    color = Color.White,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold
+                )
+            }
+            
+            Spacer(modifier = Modifier.width(Spacing.Small))
+            
+            // Stop details card
+            Card(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(start = Spacing.Small),
+                elevation = CardDefaults.cardElevation(defaultElevation = 2.dp),
+                colors = CardDefaults.cardColors(containerColor = Color.White),
+                shape = RoundedCornerShape(Spacing.CornerRadius),
+                border = androidx.compose.foundation.BorderStroke(
+                    width = 1.dp,
+                    color = Color.LightGray
+                )
+            ) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(Spacing.Medium),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Place,
+                        contentDescription = null,
+                        tint = Color.Gray,
+                        modifier = Modifier.size(24.dp)
+                    )
+                    
+                    Spacer(modifier = Modifier.width(Spacing.Small))
+                    
+                    Column {
+                        Text(
+                            text = stop.name,
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.Medium,
+                            color = Color.Black
+                        )
+                        
+                        if (stop.category != null) {
+                            val categoryUi = stop.category.toUi()
+                            Row(
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                Icon(
+                                    imageVector = categoryUi.icon,
+                                    contentDescription = null,
+                                    tint = Color.Gray,
+                                    modifier = Modifier.size(16.dp)
+                                )
+                                Spacer(modifier = Modifier.width(4.dp))
+                                Text(
+                                    text = stringResource(categoryUi.titleResource),
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    color = Color.Gray
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        
+        // Connector line (except for the last item)
+        if (showConnector && !isLast) {
+            Spacer(modifier = Modifier.height(Spacing.Small))
+            
+            // Draw dashed line connector
+            Canvas(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(40.dp)
+                    .padding(start = 20.dp)
+            ) {
+                val path = Path().apply {
+                    moveTo(0f, 0f)
+                    lineTo(0f, size.height)
+                }
+                
+                drawPath(
+                    path = path,
+                    color = OrangeMain,
+                    style = Stroke(
+                        width = 2.dp.toPx(),
+                        pathEffect = androidx.compose.ui.graphics.PathEffect.dashPathEffect(
+                            floatArrayOf(10f, 10f)
+                        )
+                    )
+                )
+            }
+            
+            Spacer(modifier = Modifier.height(Spacing.Small))
+        }
+    }
+}

--- a/app/src/main/java/com/github/eylulnc/walkmunich/feature/route/ui/RouteDetailScreenUi.kt
+++ b/app/src/main/java/com/github/eylulnc/walkmunich/feature/route/ui/RouteDetailScreenUi.kt
@@ -30,7 +30,6 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.key
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -47,7 +46,6 @@ import com.github.eylulnc.walkmunich.core.ui.theme.Spacing
 import com.github.eylulnc.walkmunich.core.ui.theme.TypographySizes
 import com.github.eylulnc.walkmunich.feature.route.viewmodel.RouteDetailViewModel
 import org.koin.androidx.compose.koinViewModel
-import org.koin.core.parameter.parametersOf
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -143,19 +141,17 @@ private fun RouteDetailContent(routeDetail: RouteDetail) {
                 ItinerarySegment(
                     segment = segment,
                     displaySubtitle = routeDetail.segments.size != 1
-
                 )
             }
         }
     }
 }
 
-
 @Composable
 private fun ItinerarySegment(
     segment: RouteSegment,
     displaySubtitle: Boolean
-    ) {
+) {
     Column(
         modifier = Modifier.padding(Spacing.Medium),
         verticalArrangement = Arrangement.spacedBy(Spacing.Medium)

--- a/app/src/main/java/com/github/eylulnc/walkmunich/feature/route/ui/RouteDetailScreenUi.kt
+++ b/app/src/main/java/com/github/eylulnc/walkmunich/feature/route/ui/RouteDetailScreenUi.kt
@@ -30,6 +30,7 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -51,13 +52,9 @@ import org.koin.core.parameter.parametersOf
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun RouteDetailScreenUi(
-    routeId: Long,
+    viewModel: RouteDetailViewModel = koinViewModel(),
     onBackClick: () -> Unit
 ) {
-    val viewModel: RouteDetailViewModel = koinViewModel<RouteDetailViewModel> {
-        parametersOf(routeId)
-    }
-
     val state by viewModel.uiState.collectAsStateWithLifecycle()
 
     Column(

--- a/app/src/main/java/com/github/eylulnc/walkmunich/feature/route/viewmodel/RouteDetailViewModel.kt
+++ b/app/src/main/java/com/github/eylulnc/walkmunich/feature/route/viewmodel/RouteDetailViewModel.kt
@@ -1,0 +1,46 @@
+package com.github.eylulnc.walkmunich.feature.route.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.github.eylulnc.walkmunich.core.data.model.RouteDetail
+import com.github.eylulnc.walkmunich.feature.route.data.RoutesRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+data class RouteDetailUiState(
+    val isLoading: Boolean = true,
+    val routeDetail: RouteDetail? = null,
+    val error: String? = null
+)
+
+class RouteDetailViewModel(
+    private val repository: RoutesRepository,
+    private val routeId: Long
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(RouteDetailUiState())
+    val uiState: StateFlow<RouteDetailUiState> = _uiState
+
+    init {
+        loadRouteDetail()
+    }
+
+    private fun loadRouteDetail() {
+        _uiState.update { it.copy(isLoading = true, error = null) }
+        viewModelScope.launch {
+            runCatching {
+                repository.getRouteDetail(routeId)
+            }.onSuccess { routeDetail ->
+                _uiState.update { it.copy(isLoading = false, routeDetail = routeDetail) }
+            }.onFailure { e ->
+                _uiState.update { it.copy(isLoading = false, error = e.message) }
+            }
+        }
+    }
+
+    fun retry() {
+        loadRouteDetail()
+    }
+}

--- a/app/src/main/java/com/github/eylulnc/walkmunich/navigation/NavigationRoot.kt
+++ b/app/src/main/java/com/github/eylulnc/walkmunich/navigation/NavigationRoot.kt
@@ -25,7 +25,7 @@ import androidx.navigation3.runtime.rememberNavBackStack
 import androidx.navigation3.runtime.rememberSavedStateNavEntryDecorator
 import androidx.navigation3.ui.NavDisplay
 import androidx.navigation3.ui.rememberSceneSetupNavEntryDecorator
-import com.github.eylulnc.walkmunich.feature.main.ui.MainScreenUi
+import com.github.eylulnc.walkmunich.feature.home.ui.MainScreenUi
 import com.github.eylulnc.walkmunich.feature.route.ui.RouteListScreenUi
 import com.github.eylulnc.walkmunich.core.ui.theme.OrangeMain
 import com.github.eylulnc.walkmunich.core.ui.theme.Spacing

--- a/app/src/main/java/com/github/eylulnc/walkmunich/navigation/NavigationRoot.kt
+++ b/app/src/main/java/com/github/eylulnc/walkmunich/navigation/NavigationRoot.kt
@@ -13,6 +13,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -123,13 +124,15 @@ fun NavigationRoot(
                                 }
                                 RouteScreen.Detail -> {
                                     selectedRouteId?.let { routeId ->
-                                        RouteDetailScreenUi(
-                                            routeId = routeId,
-                                            onBackClick = { 
-                                                currentRouteScreen = RouteScreen.List
-                                                selectedRouteId = null
-                                            }
-                                        )
+                                        key(routeId) {
+                                            RouteDetailScreenUi(
+                                                routeId = routeId,
+                                                onBackClick = { 
+                                                    currentRouteScreen = RouteScreen.List
+                                                    selectedRouteId = null
+                                                }
+                                            )
+                                        }
                                     } ?: RouteListScreenUi(
                                         onRouteClick = { routeId ->
                                             selectedRouteId = routeId

--- a/app/src/main/java/com/github/eylulnc/walkmunich/navigation/RootKeys.kt
+++ b/app/src/main/java/com/github/eylulnc/walkmunich/navigation/RootKeys.kt
@@ -6,3 +6,4 @@ import kotlinx.serialization.Serializable
 @Serializable data object MainScreen : NavKey
 @Serializable data object RouteListScreen : NavKey
 @Serializable data object FavoritesScreen : NavKey
+@Serializable data class RouteDetailScreen(val routeId: Long) : NavKey


### PR DESCRIPTION
### Description
When the user clicks on a route item (e.g., *1-Day itinerary*, *3-Day itinerary*) from the **Route list screen**, they should be navigated to a **Route details screen**.

The Route details screen displays the ordered list of locations included in the itinerary. Each location should show:
- **Order number** (1, 2, 3, …)
- **Name** (e.g., *Marienplatz*)
- **Category icon** (🏛 for landmarks, ☕️ for cafés, etc.)
- **Consecutive order** (locations listed in sequence, if more than one exists)

---

- [x] The screen displays all locations in the selected route in **ordered sequence**  
- [x] Each location item shows:
  - Step number (circular orange label with order)  
  - Location name  
  - Category icon  
- [x] If multiple routes exist, they should all be listed consecutively in their respective order  

---

https://github.com/user-attachments/assets/543bdd86-c9b8-4861-abbd-bdb4dfe73e82

<img width="259" height="500" alt="Screenshot 2025-08-29 at 02 57 26" src="https://github.com/user-attachments/assets/99b3799a-d834-4fa3-a91d-a6f413ee46b0" />

