### PR TITLE
Improvement: Add view toggle for favorites

### DIFF
--- a/app/src/main/java/com/github/eylulnc/walkmunich/core/data/repository/UserPreferencesRepository.kt
+++ b/app/src/main/java/com/github/eylulnc/walkmunich/core/data/repository/UserPreferencesRepository.kt
@@ -18,6 +18,7 @@ class UserPreferencesRepository(private val context: Context) {
     private val isDarkThemeKey = booleanPreferencesKey("is_dark_theme")
     private val favoritePlacesKey = stringSetPreferencesKey("favorite_places")
     private val recentlyViewedKey = stringPreferencesKey("recently_viewed_places")
+    private val isGridViewKey = booleanPreferencesKey("is_grid_view")
 
     val isDarkTheme: Flow<Boolean> = context.dataStore.data
         .map { preferences ->
@@ -32,6 +33,11 @@ class UserPreferencesRepository(private val context: Context) {
     val recentlyViewedPlaceIds: Flow<List<String>> = context.dataStore.data
         .map { preferences ->
             preferences[recentlyViewedKey]?.split(",")?.filter { it.isNotEmpty() } ?: emptyList()
+        }
+
+    val isGridView: Flow<Boolean> = context.dataStore.data
+        .map { preferences ->
+            preferences[isGridViewKey] ?: true
         }
 
     suspend fun setDarkTheme(isDarkTheme: Boolean) {
@@ -62,6 +68,12 @@ class UserPreferencesRepository(private val context: Context) {
             val limitedList = currentList.take(6)
 
             preferences[recentlyViewedKey] = limitedList.joinToString(",")
+        }
+    }
+
+    suspend fun setGridView(isGridView: Boolean) {
+        context.dataStore.edit { preferences ->
+            preferences[isGridViewKey] = isGridView
         }
     }
 }

--- a/app/src/main/java/com/github/eylulnc/walkmunich/feature/favorite/ui/FavoritesScreenUi.kt
+++ b/app/src/main/java/com/github/eylulnc/walkmunich/feature/favorite/ui/FavoritesScreenUi.kt
@@ -4,9 +4,16 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.GridView
+import androidx.compose.material.icons.outlined.ViewAgenda
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -15,6 +22,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.text.font.FontWeight
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.github.eylulnc.walkmunich.core.ui.composable.LoadingState
+import com.github.eylulnc.walkmunich.core.ui.composable.PlaceCardLarge
 import com.github.eylulnc.walkmunich.core.ui.composable.PlaceCardSmall
 import com.github.eylulnc.walkmunich.core.ui.composable.WMTopAppBarScreen
 import com.github.eylulnc.walkmunich.core.ui.theme.Spacing
@@ -31,7 +39,16 @@ fun FavoritesScreenUi(
 
     WMTopAppBarScreen(
         title = "Favorites",
-        onBack = null
+        onBack = null,
+        actions = {
+            IconButton(onClick = { viewModel.onToggleLayout() }) {
+                Icon(
+                    imageVector = if (state.isGridView) Icons.Outlined.ViewAgenda else Icons.Default.GridView,
+                    contentDescription = "Toggle Layout",
+                    tint = MaterialTheme.colorScheme.primary
+                )
+            }
+        }
     ) { modifier ->
         when {
             state.isLoading && state.favoritePlaces.isEmpty() -> LoadingState()
@@ -48,7 +65,7 @@ fun FavoritesScreenUi(
                     )
                 }
             }
-            else -> {
+            state.isGridView -> {
                 LazyVerticalGrid(
                     modifier = modifier.fillMaxSize(),
                     columns = GridCells.Fixed(2),
@@ -58,6 +75,22 @@ fun FavoritesScreenUi(
                 ) {
                     items(state.favoritePlaces) { place ->
                         PlaceCardSmall(
+                            place = place,
+                            onPlaceClick = { onPlaceClick(place.id) },
+                            isFavorite = true,
+                            onFavoriteClick = { viewModel.onToggleFavorite(place.id) }
+                        )
+                    }
+                }
+            }
+            else -> {
+                LazyColumn(
+                    modifier = modifier.fillMaxSize(),
+                    contentPadding = PaddingValues(Spacing.Medium),
+                    verticalArrangement = Arrangement.spacedBy(Spacing.Medium)
+                ) {
+                    items(state.favoritePlaces) { place ->
+                        PlaceCardLarge(
                             place = place,
                             onPlaceClick = { onPlaceClick(place.id) },
                             isFavorite = true,

--- a/app/src/main/java/com/github/eylulnc/walkmunich/feature/favorite/viewmodel/FavoritesViewModel.kt
+++ b/app/src/main/java/com/github/eylulnc/walkmunich/feature/favorite/viewmodel/FavoritesViewModel.kt
@@ -8,6 +8,7 @@ import com.github.eylulnc.walkmunich.core.data.repository.UserPreferencesReposit
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
@@ -15,6 +16,7 @@ data class FavoritesScreenUiState(
     val isLoading: Boolean = false,
     val favoritePlaces: List<Place> = emptyList(),
     val favoritePlaceIds: Set<String> = emptySet(),
+    val isGridView: Boolean = true,
     val error: String? = null
 )
 
@@ -32,8 +34,13 @@ class FavoritesViewModel(
 
     private fun observeFavorites() {
         viewModelScope.launch {
-            userPreferencesRepository.favoritePlaceIds.collectLatest { favoriteIds ->
-                _uiState.update { it.copy(favoritePlaceIds = favoriteIds, isLoading = true) }
+            combine(
+                userPreferencesRepository.favoritePlaceIds,
+                userPreferencesRepository.isGridView
+            ) { favoriteIds, isGridView ->
+                Pair(favoriteIds, isGridView)
+            }.collectLatest { (favoriteIds, isGridView) ->
+                _uiState.update { it.copy(favoritePlaceIds = favoriteIds, isGridView = isGridView, isLoading = true) }
                 loadFavoritePlaces(favoriteIds)
             }
         }
@@ -54,6 +61,12 @@ class FavoritesViewModel(
     fun onToggleFavorite(placeId: Long) {
         viewModelScope.launch {
             userPreferencesRepository.toggleFavorite(placeId.toString())
+        }
+    }
+
+    fun onToggleLayout() {
+        viewModelScope.launch {
+            userPreferencesRepository.setGridView(!_uiState.value.isGridView)
         }
     }
 }


### PR DESCRIPTION
## Description

This PR implements the logic and UI required to display favorite places on the **Favorites** tab, including a persistent layout toggle between **Grid** and **List** views.

---

## Key Changes

### Data Persistence
- Updated `UserPreferencesRepository` to store the user's layout preference (`isGridView`) using **Jetpack DataStore**.

### ViewModel Logic
- Enhanced `FavoritesViewModel` to:
  - Observe both the favorite place IDs and the saved layout preference.
  - Fetch and filter full `Place` objects from the repository based on the stored favorite IDs.
  - Expose a toggle method to switch between Grid and List layouts.

### UI Enhancements
- **FavoritesScreenUi**
  - Added a layout toggle button in the `WMTopAppBar`.

- **Dynamic Layouts**
  - Implemented conditional rendering to switch between:
    - a **2-column Grid** using `PlaceCardSmall`
    - a **1-column List** using `PlaceCardLarge`

- **State Synchronization**
  - The screen now automatically refreshes whenever a place is favorited or unfavorited anywhere in the app.

- **Empty State**
  - Added a *“No favorites yet”* message when the favorites list is empty.
  

<img width="282" height="528" alt="Screenshot 2026-01-18 at 22 50 29" src="https://github.com/user-attachments/assets/d636bcbf-42dc-4932-952d-e8758f17149e" />
<img width="282" height="528" alt="Screenshot 2026-01-18 at 22 50 26" src="https://github.com/user-attachments/assets/1eabdaf1-9589-4bcd-809e-78b5618f373e" />

