### PR TITLE
Feature: Display Pop up for Disclaimer on first launch

### DIFF
--- a/app/src/main/java/com/github/eylulnc/walkmunich/MainActivity.kt
+++ b/app/src/main/java/com/github/eylulnc/walkmunich/MainActivity.kt
@@ -5,10 +5,13 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.github.eylulnc.walkmunich.core.data.repository.UserPreferencesRepository
+import com.github.eylulnc.walkmunich.core.ui.composable.DisclaimerDialog
 import com.github.eylulnc.walkmunich.navigation.NavigationRoot
 import com.github.eylulnc.walkmunich.core.ui.theme.WalkMunichTheme
+import kotlinx.coroutines.launch
 import org.koin.android.ext.android.inject
 
 class MainActivity : ComponentActivity() {
@@ -20,8 +23,21 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         setContent {
             val isDarkTheme by userPreferencesRepository.isDarkTheme.collectAsStateWithLifecycle(initialValue = false)
+            val hasSeenDisclaimer by userPreferencesRepository.hasSeenDisclaimer.collectAsStateWithLifecycle(initialValue = true)
+            val scope = rememberCoroutineScope()
+
             WalkMunichTheme(darkTheme = isDarkTheme) {
                 NavigationRoot()
+
+                if (!hasSeenDisclaimer) {
+                    DisclaimerDialog(
+                        onConfirm = {
+                            scope.launch {
+                                userPreferencesRepository.setHasSeenDisclaimer(true)
+                            }
+                        }
+                    )
+                }
             }
         }
     }

--- a/app/src/main/java/com/github/eylulnc/walkmunich/core/data/repository/UserPreferencesRepository.kt
+++ b/app/src/main/java/com/github/eylulnc/walkmunich/core/data/repository/UserPreferencesRepository.kt
@@ -19,6 +19,7 @@ class UserPreferencesRepository(private val context: Context) {
     private val favoritePlacesKey = stringSetPreferencesKey("favorite_places")
     private val recentlyViewedKey = stringPreferencesKey("recently_viewed_places")
     private val isGridViewKey = booleanPreferencesKey("is_grid_view")
+    private val hasSeenDisclaimerKey = booleanPreferencesKey("has_seen_disclaimer")
 
     val isDarkTheme: Flow<Boolean> = context.dataStore.data
         .map { preferences ->
@@ -38,6 +39,11 @@ class UserPreferencesRepository(private val context: Context) {
     val isGridView: Flow<Boolean> = context.dataStore.data
         .map { preferences ->
             preferences[isGridViewKey] ?: true
+        }
+
+    val hasSeenDisclaimer: Flow<Boolean> = context.dataStore.data
+        .map { preferences ->
+            preferences[hasSeenDisclaimerKey] ?: false
         }
 
     suspend fun setDarkTheme(isDarkTheme: Boolean) {
@@ -74,6 +80,12 @@ class UserPreferencesRepository(private val context: Context) {
     suspend fun setGridView(isGridView: Boolean) {
         context.dataStore.edit { preferences ->
             preferences[isGridViewKey] = isGridView
+        }
+    }
+
+    suspend fun setHasSeenDisclaimer(hasSeen: Boolean) {
+        context.dataStore.edit { preferences ->
+            preferences[hasSeenDisclaimerKey] = hasSeen
         }
     }
 }

--- a/app/src/main/java/com/github/eylulnc/walkmunich/core/ui/composable/DisclaimerDialog.kt
+++ b/app/src/main/java/com/github/eylulnc/walkmunich/core/ui/composable/DisclaimerDialog.kt
@@ -14,7 +14,7 @@ fun DisclaimerDialog(
     onConfirm: () -> Unit
 ) {
     AlertDialog(
-        onDismissRequest = { /* Mandatory acknowledgment */ },
+        onDismissRequest = { },
         properties = DialogProperties(
             dismissOnBackPress = false,
             dismissOnClickOutside = false

--- a/app/src/main/java/com/github/eylulnc/walkmunich/core/ui/composable/DisclaimerDialog.kt
+++ b/app/src/main/java/com/github/eylulnc/walkmunich/core/ui/composable/DisclaimerDialog.kt
@@ -1,0 +1,37 @@
+package com.github.eylulnc.walkmunich.core.ui.composable
+
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.window.DialogProperties
+import com.github.eylulnc.walkmunich.R
+
+@Composable
+fun DisclaimerDialog(
+    onConfirm: () -> Unit
+) {
+    AlertDialog(
+        onDismissRequest = { /* Mandatory acknowledgment */ },
+        properties = DialogProperties(
+            dismissOnBackPress = false,
+            dismissOnClickOutside = false
+        ),
+        title = {
+            Text(
+                text = stringResource(R.string.about_disclaimer_title),
+                fontWeight = FontWeight.Bold
+            )
+        },
+        text = {
+            Text(text = stringResource(R.string.disclaimer_first_launch_message))
+        },
+        confirmButton = {
+            TextButton(onClick = onConfirm) {
+                Text(text = stringResource(R.string.disclaimer_understand_button))
+            }
+        }
+    )
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -51,6 +51,11 @@
         Walk Munich is a non-commercial, personal project created for learning, experimentation, and portfolio purposes.\n\nIt is not an official city guide and is not affiliated with the City of Munich, local authorities, or any tourism organization.\n\nRoutes, place descriptions, and recommendations reflect personal suggestions and interpretations and may not be complete, up to date, or suitable for every user.\n\nAll information is provided “as is” without any guarantees regarding accuracy or reliability.
     </string>
 
+    <string name="disclaimer_first_launch_message">
+    This app is a personal and educational project created for learning, exploration, and portfolio purposes. It is not affiliated with any official tourism organization or authority. Content is curated from publicly available sources and provided for informational purposes only.
+    </string>
+    <string name="disclaimer_understand_button">I Understand</string>
+
     <!-- Attribution -->
     <string name="about_attribution_title">Attribution &amp; Sources</string>
     <string name="about_attribution">


### PR DESCRIPTION
### Description
The purpose of the PR show users a disclaimer when they first open the app.  
The disclaimer should state that this app is a **non-profit, personal project**, created **for portfolio and fun purposes only**, and not affiliated with any official organization.  

### Requirements
- Display a **modal dialog** or a **dedicated screen** on first app launch:
  - Title: "Disclaimer"  
  - Message
  - Button: "I Understand" → continues to Home.  
- Persist the user’s acknowledgment in `DataStore`/`SharedPreferences`:
  - `hasSeenDisclaimer = true`.  
- Only show this disclaimer on **first launch**.  

### Acceptance Criteria
- [x] On first launch, disclaimer is shown and must be acknowledged before entering the app.  
- [x] On subsequent launches, disclaimer does **not** show again.  
- [x] Text clearly states non-profit and personal/portfolio purpose.  

### Notes
- Avoid showing disclaimer on every launch to prevent annoyance.

## Summary by Sourcery

Show a mandatory one-time disclaimer dialog on first app launch and persist the user’s acknowledgment in preferences so it does not reappear.

New Features:
- Add a first-launch disclaimer dialog explaining the app’s personal, non-commercial nature with an acknowledgment button.

Enhancements:
- Extend the user preferences repository with a stored flag tracking whether the disclaimer has been seen.